### PR TITLE
endsNextDay() incorrect

### DIFF
--- a/util/src/main/java/de/outstare/kinosim/util/TimeRange.java
+++ b/util/src/main/java/de/outstare/kinosim/util/TimeRange.java
@@ -59,7 +59,8 @@ public class TimeRange {
 	 * @return <code>true</code> if the end of this time range is an the next day.
 	 */
 	public boolean endsNextDay() {
-		return start.isAfter(end);
+		return start.getHour() <= LocalTime.MAX.getHour()  && start.getHour() > LocalTime.NOON.getHour()
+        		&& end.getHour() >= LocalTime.MIN.getHour() && end.getHour() < LocalTime.NOON.getHour();
 	}
 
 	public Duration getDuration() {


### PR DESCRIPTION
The method endsNextDay() is not fully correct. See the test file I've created:

public class TimeRangeTest {

```
LocalTime start1, end1, 
            start2, end2;

@Before
public void before(){
    start1 = LocalTime.of(10, 17, 5);
    end1 = LocalTime.of(10, 17, 0);
    start2 = LocalTime.of(23, 59, 51);
    end2 = LocalTime.of(0, 2, 29);
}

@Test
public void test(){
    TimeRange rngNo = new TimeRange(start1, end1);
    assertFalse(rngNo.endsNextDay());
    TimeRange rngYes = new TimeRange(start2, end2);
    assertTrue(rngYes.endsNextDay());
}

@After
public void after(){
    start1 = null;
    end1 = null;
    start2 = null;
    end2 = null;
}
```

}
